### PR TITLE
modified form.py for better display of multiple values

### DIFF
--- a/neuronsimulator/forms.py
+++ b/neuronsimulator/forms.py
@@ -105,6 +105,7 @@ class ParamForm(forms.Form):
                     "data-live-search": "true",
                     "data-width": "fit",
                     "data-actions-box": "true",
+                    "data-selected-text-format": "count > 12",
                     "title": "Choose neurons a priori",
                 }
             ),


### PR DESCRIPTION
## Summary

- improved display of multiple selected values without using default setting for `selectedTextFormat` of [Bootstrap-select](https://developer.snapappointments.com/bootstrap-select/options/).
  - added one line to `forms.py`
  - display selected multiple response neurons until total count=<12, then display total count
  - The cut-off value is set to 12 to keep selected values in defined form area.
  